### PR TITLE
Add bulk_items endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ Additionaly, the STAC API Transaction Extension supports optimistic locking thro
 | Path                                                   | Content-Type Header | Body                                   | Success Status | Description                                                       |
 | ------------------------------------------------------ | ------------------- | -------------------------------------- | -------------- | ----------------------------------------------------------------- |
 | `POST /collections/{collectionId}/items`               | `application/json`  | partial Item or partial ItemCollection | 201, 202       | Adds a new item to a collection.                                  |
+| `POST /collections/{collectionId}/bulk_items`          | `application/json`  | partial ItemCollection                 | 201, 202       | Adds multiple items to a collection in a single request.          |
 | `PUT /collections/{collectionId}/items/{featureId}`    | `application/json`  | partial Item                           | 200, 202, 204  | Updates an existing item by ID using a complete item description. |
 | `PATCH /collections/{collectionId}/items/{featureId}`  | `application/json`  | partial Item                           | 200, 202, 204  | Updates an existing item by ID using a partial item description.  |
 | `DELETE /collections/{collectionId}/items/{featureId}` | n/a                 | n/a                                    | 200, 202, 204  | Deletes an existing item by ID.                                   |
 
 ### POST
+
+#### POST /collections/{collectionId}/items
 
 When the body is a partial Item:
 
@@ -66,6 +69,19 @@ When the body is a partial ItemCollection:
 All cases:
 
 - Must return 202 if the operation is queued for asynchronous execution.
+
+#### POST /collections/{collectionId}/bulk_items
+
+This is an alternate version of the `POST /collections/{collectionId}/items` where the body is a partial ItemCollection. 
+
+- Must only create new resources.
+- Must accept a partial ItemCollection containing multiple Items.
+- Each Item in the ItemCollection must have an id field.
+- Must return 409 if an Item exists for any of the same collection and id values.
+- Must populate the `collection` field in each Item from the URI.
+- Must return 201 with a response body containing the status and number of items created.
+- Must return 202 if the operation is queued for asynchronous execution.
+- May create only some of the Items in the ItemCollection. Implementations are not required to implement all-or-none semantics.
 
 ### PUT
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,6 +17,53 @@ tags:
       STAC-specific operations to add, remove, and edit items within OGC API - Features
       collections.
 paths:
+  "/collections/{collectionId}/bulk_items":
+    parameters:
+      - $ref: "https://api.stacspec.org/v1.0.0/ogcapi-features/openapi.yaml#/components/parameters/collectionId"
+    post:
+      summary: Add multiple STAC Items to a collection in a single request
+      description: Create multiple STAC Items in a specific collection using a single request. This endpoint is optimized for bulk insertions.
+      operationId: bulkPostFeatures
+      tags:
+        - Transaction
+      requestBody:
+        description: The request body must contain a FeatureCollection of STAC Items to insert
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/postOrPutItemCollection"
+      responses:
+        "201":
+          description: The items were created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - created
+                properties:
+                  status:
+                    type: string
+                    enum: [success]
+                  created:
+                    type: integer
+                    description: Number of items successfully created
+        "202":
+          description: The items were accepted for asynchronous processing
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "https://api.stacspec.org/v1.0.0/ogcapi-features/openapi.yaml#/components/responses/NotFound"
+        "500":
+          $ref: "https://api.stacspec.org/v1.0.0/ogcapi-features/openapi.yaml#/components/responses/Error"
+        default:
+          description: An error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: "https://api.stacspec.org/v1.0.0/ogcapi-features/openapi.yaml#/components/schemas/exception"
+
   "/collections/{collectionId}/items":
     parameters:
       - $ref: "https://api.stacspec.org/v1.0.0/ogcapi-features/openapi.yaml#/components/parameters/collectionId"


### PR DESCRIPTION
This PR reflect de facto implementation of bulk items POST in [stac-fastapi-pgstac](https://github.com/stac-utils/stac-fastapi-pgstac/blob/main/stac_fastapi/pgstac/transactions.py#L208)

**Proposed Changes:**

1. Add `POST /collections/{collectionId}/bulk_items`

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/stac-api-extensions/transaction/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
